### PR TITLE
Define the size of all the matrices as a funciton of the total number of vertices

### DIFF
--- a/lib/+mwbs/@Contacts/compute_unilateral_linear_impact.m
+++ b/lib/+mwbs/@Contacts/compute_unilateral_linear_impact.m
@@ -162,7 +162,7 @@ elseif obj.useQPOASES
     
     A_phase_II = [obj.A; -diag(obj.is_in_contact)*H_n; expandedNormalForces];
     A_Ub_phase_II = [obj.Ax_Ub; diag(obj.is_in_contact)*g_n; maximumNormalForceMagnitude];
-    A_Lb_phase_II = -1e10 + zeros(1+(5+1)*8,1);
+    A_Lb_phase_II = -1e10 + zeros(1+(5+1)* obj.num_vertices * num_in_contact_frames,1);
     
     [contactForces, ~] = simFunc_qpOASES_impact_phase_II(H, g, A_phase_II, A_Lb_phase_II, A_Ub_phase_II, -obj.ulb, obj.ulb);
     


### PR DESCRIPTION
As we tested in a local repository, we saw that the simulator generates error when the number of the links interacting with the ground is not equal to 2. In fact, the size of some matrices defined as fixed numbers assuming that there are 8 number of vertices. In this PR, we define the size of all matrices as a function of the total number of the vertices.