### PR TITLE
Use filesep instead of platform-specific '/' for Windows compatibility

### DIFF
--- a/lib/+mwbs/getModelPathFromFileNameAndYarpFinder.m
+++ b/lib/+mwbs/getModelPathFromFileNameAndYarpFinder.m
@@ -11,8 +11,8 @@ if isempty(modelPath) % if the model path is not mentioned in the robot file nam
 	% Get the model file
 	modelPathFromYarpFinder = YarpRF.findFileByName(robotFileName);
 	% Just return the parent folder path
-	modelPath = strcat(fileparts(modelPathFromYarpFinder),'/');
+	modelPath = strcat(fileparts(modelPathFromYarpFinder),filesep);
 else
-	modelPath = strcat(modelPath,'/');
+	modelPath = strcat(modelPath,filesep);
 	robotFileName = erase(robotFileName,modelPath);
 end


### PR DESCRIPTION
I was running some simulation on Windows and I noticed some strange prints like:
~~~
Loading model C:/path\C:/path/model.urdf
~~~

I understood then that the logic of the `getModelPathFromFileNameAndYarpFinder.m` function does not work correctly unless `filesep` is used in place of [`/`](https://mathworks.com/help/matlab/ref/filesep.html).